### PR TITLE
Allow setting of uDMX connection options

### DIFF
--- a/PyDMXControl/controllers/_uDMXController.py
+++ b/PyDMXControl/controllers/_uDMXController.py
@@ -14,6 +14,10 @@ class uDMXController(transmittingController):
 
     def __init__(self, *args, **kwargs):
         self.udmx = None
+        self.udmx_vendor_id = kwargs.pop("u dmx_vendor_id", 0x16c0)
+        self.udmx_product_id = kwargs.pop("udmx_product_id", 0x5dc)
+        self.udmx_bus = kwargs.pop("udmx_bus", None)
+        self.udmx_address = kwargs.pop("udmx_address", None)
         self.__connect()
 
         super().__init__(*args, **kwargs)
@@ -35,7 +39,7 @@ class uDMXController(transmittingController):
                 pass
         # Get new device
         self.udmx = pyudmx.uDMXDevice()
-        self.udmx.open()
+        self.udmx.open(self.udmx_vendor_id, self.udmx_product_id, self.udmx_bus, self.udmx_address)
 
     def _send_data(self):
         # Get the data

--- a/PyDMXControl/controllers/_uDMXController.py
+++ b/PyDMXControl/controllers/_uDMXController.py
@@ -13,18 +13,18 @@ from ._transmittingController import transmittingController
 class uDMXController(transmittingController):
 
     def __init__(self, *args, **kwargs):
-        self.udmx = None
-        self.udmx_vendor_id = kwargs.pop("u dmx_vendor_id", 0x16c0)
-        self.udmx_product_id = kwargs.pop("udmx_product_id", 0x5dc)
-        self.udmx_bus = kwargs.pop("udmx_bus", None)
-        self.udmx_address = kwargs.pop("udmx_address", None)
+        self.__udmx = None
+        self.__udmx_vendor_id = kwargs.pop("udmx_vendor_id", 0x16c0)
+        self.__udmx_product_id = kwargs.pop("udmx_product_id", 0x5dc)
+        self.__udmx_bus = kwargs.pop("udmx_bus", None)
+        self.__udmx_address = kwargs.pop("udmx_address", None)
         self.__connect()
 
         super().__init__(*args, **kwargs)
 
     def close(self):
         # uDMX
-        self.udmx.close()
+        self.__udmx.close()
         print("CLOSE: uDMX closed")
 
         # Parent
@@ -32,14 +32,14 @@ class uDMXController(transmittingController):
 
     def __connect(self):
         # Try to close if exists
-        if self.udmx is not None:
+        if self.__udmx is not None:
             try:
-                self.udmx.close()
+                self.__udmx.close()
             except Exception:
                 pass
         # Get new device
-        self.udmx = pyudmx.uDMXDevice()
-        self.udmx.open(self.udmx_vendor_id, self.udmx_product_id, self.udmx_bus, self.udmx_address)
+        self.__udmx = pyudmx.uDMXDevice()
+        self.__udmx.open(self.__udmx_vendor_id, self.__udmx_product_id, self.__udmx_bus, self.__udmx_address)
 
     def _send_data(self):
         # Get the data
@@ -53,7 +53,7 @@ class uDMXController(transmittingController):
             try:
                 if retry_count > 5:
                     self.__connect()
-                self.udmx.send_multi_value(1, data)
+                self.__udmx.send_multi_value(1, data)
                 success = True
             except Exception as e:
                 retry_count += 1


### PR DESCRIPTION
 - Allows the setting of the uDMX vendor id through the `udmx_vendor_id` keyword argument when creating the controller.
 - Allows setting of product id for uDMX with keyword argument `udmx_product_id` when creating the uDMX controller.
 - Allow the uDMX USB bus to be defined by specifying the keyword argument `udmx_bus` during controller creation.
 - Allows the setting of the uDMX USB address by providing a value with the `udmx_address` keyword argument during controller instantiation.
 - Breaking Change: makes the udmx instance private within the controller to mitigate the possibility of someone breaking it.