### PR TITLE
Fix Fixture.color() function

### DIFF
--- a/PyDMXControl/profiles/defaults/_Fixture.py
+++ b/PyDMXControl/profiles/defaults/_Fixture.py
@@ -77,7 +77,7 @@ class FixtureHelpers:
     def color(self, color: Union[Colors, List[int], Tuple[int], str], milliseconds: int = 0):
         # Handle string color names
         if isinstance(color, str):
-            if color in Colors:
+            if color in Colors.__members__:
                 color = Colors[color]
             else:
                 raise ValueError("Color '" + color + "' not defined in Colors enum."


### PR DESCRIPTION
When a string was passed to the color function, this would always raise a ValueError. This should fix it