### PR TITLE
Refactor Colors using itertools

### DIFF
--- a/PyDMXControl/_Colors.py
+++ b/PyDMXControl/_Colors.py
@@ -5,10 +5,10 @@
  *  Copyright (C) 2018 Matt Cowley (MattIPv4) (me@mattcowley.co.uk)
 """
 
+import itertools
 from enum import Enum
 from typing import List, Dict, Tuple, Union
 
-import itertools
 
 class Colors(list, Enum):
 
@@ -25,7 +25,7 @@ class Colors(list, Enum):
 
         Returns
         -------
-        int
+        Union[int, float]
             Clamped value. [lo..hi]
         
         Examples

--- a/PyDMXControl/_Colors.py
+++ b/PyDMXControl/_Colors.py
@@ -13,19 +13,20 @@ import itertools
 class Colors(list, Enum):
 
     @staticmethod
-    def clamp(val: Union[int, float]) -> int:
+    def clamp(val: Union[int, float], lo: int = 0, hi: int = 255) -> Union[int, float]:
         """
-        Clamp a color to ensure it fits in range [0..255]
-        and convert it to an integer.
+        Clamp a value to ensure it fits in a range (default [0..255])
 
         Parameters
         ----------
         val: Value to clamp.
+        lo: Minimum value.
+        hi: Maximum value.
 
         Returns
         -------
         int
-            Clamped value. [0..255]
+            Clamped value. [lo..hi]
         
         Examples
         --------
@@ -33,7 +34,7 @@ class Colors(list, Enum):
         >>> Colors.clamp(2323.52)
         255
         """
-        return int(min(255, max(0, val)))
+        return min(hi, max(lo, val))
 
     @staticmethod
     def mix(color1: List[int], color2: List[int], percent: float = 0.5) -> List[int]:
@@ -58,15 +59,14 @@ class Colors(list, Enum):
         >>> Colors.mix([0,128,0], [128,0,128], 0.5)    
         [64, 64, 64]
         """
-        if percent < 0 or percent > 1:
-            percent = 0.5
+        percent = Colors.clamp(percent, 0, 1)
 
         result = []
         for val1, val2 in itertools.zip_longest(color1, color2, fillvalue=0):
             val1 *= percent
             val2 *= 1 - percent
             res = Colors.clamp(val1 + val2)
-            result.append(res)
+            result.append(int(res))
 
         return result
 
@@ -94,18 +94,16 @@ class Colors(list, Enum):
         >>> Colors.add([0,128,0], [128,0,128], 1, 0.75)
         [96, 128, 96]
         """
-        if percent1 < 0 or percent1 > 1:
-            percent1 = 1
 
-        if percent2 < 0 or percent2 > 1:
-            percent2 = 1
+        percent1 = Colors.clamp(percent1, 0, 1)
+        percent2 = Colors.clamp(percent2, 0, 1)
 
         result = []
         for val1, val2 in itertools.zip_longest(color1, color2, fillvalue=0):
             val1 *= percent1
             val2 *= percent2
             res = Colors.clamp(val1 + val2)
-            result.append(res)
+            result.append(int(res))
 
         return result
 

--- a/PyDMXControl/_Colors.py
+++ b/PyDMXControl/_Colors.py
@@ -6,10 +6,34 @@
 """
 
 from enum import Enum
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Union
 
+import itertools
 
 class Colors(list, Enum):
+
+    @staticmethod
+    def clamp(val: Union[int, float]) -> int:
+        """
+        Clamp a color to ensure it fits in range [0..255]
+        and convert it to an integer.
+
+        Parameters
+        ----------
+        val: Value to clamp.
+
+        Returns
+        -------
+        int
+            Clamped value. [0..255]
+        
+        Examples
+        --------
+
+        >>> Colors.clamp(2323.52)
+        255
+        """
+        return int(min(255, max(0, val)))
 
     @staticmethod
     def mix(color1: List[int], color2: List[int], percent: float = 0.5) -> List[int]:
@@ -38,15 +62,11 @@ class Colors(list, Enum):
             percent = 0.5
 
         result = []
-        for i in range(max(len(color1), len(color2))):
-            val1 = color1[i] if i < len(color1) else 0
-            val2 = color2[i] if i < len(color2) else 0
+        for val1, val2 in itertools.zip_longest(color1, color2, fillvalue=0):
             val1 *= percent
             val2 *= 1 - percent
-            res = val1 + val2
-            res = min(res, 255)
-            res = max(res, 0)
-            result.append(int(res))
+            res = Colors.clamp(val1 + val2)
+            result.append(res)
 
         return result
 
@@ -81,15 +101,11 @@ class Colors(list, Enum):
             percent2 = 1
 
         result = []
-        for i in range(max(len(color1), len(color2))):
-            val1 = color1[i] if i < len(color1) else 0
-            val2 = color2[i] if i < len(color2) else 0
+        for val1, val2 in itertools.zip_longest(color1, color2, fillvalue=0):
             val1 *= percent1
             val2 *= percent2
-            res = val1 + val2
-            res = min(res, 255)
-            res = max(res, 0)
-            result.append(int(res))
+            res = Colors.clamp(val1 + val2)
+            result.append(res)
 
         return result
 
@@ -114,12 +130,7 @@ class Colors(list, Enum):
         >>> Colors.to_dict([1,2,3,4,5]) 
         {'R': 1, 'G': 2, 'B': 3, 'W': 4, 'A': 5}
         """
-        keys = list('RGBWA')
-        result = {}
-        for i, color in enumerate(colors):
-            if i < len(keys):
-                result[keys[i]] = color
-        return result
+        return dict(zip('RGBWA', colors))
 
     @staticmethod
     def to_tuples(colors: List[int]) -> List[Tuple[str, int]]:
@@ -142,7 +153,7 @@ class Colors(list, Enum):
         >>> Colors.to_tuples([1,2,3,4,5]) 
         [('R', 1), ('G', 2), ('B', 3), ('W', 4), ('A', 5)]
         """
-        return [(k, v) for k, v in Colors.to_dict(colors).items()]
+        return list(zip('RGBWA', colors))
 
     @staticmethod
     def to_hex(colors: List[int]) -> str:
@@ -164,12 +175,9 @@ class Colors(list, Enum):
         '#5f5d0c'
         """
 
-        def clamp(x):
-            return max(0, min(x, 255))
-
         result = "#"
         for color in colors:
-            result += "{:02x}".format(clamp(color))
+            result += "{:02x}".format(Colors.clamp(color))
         return result
 
     @staticmethod


### PR DESCRIPTION
Improve code readability by using `itertools.zip_longest()`, `zip()` and moving `clamp()` to a separate static method.

Does not change behaviour.