### PR TITLE
Add a class to use serial port interfaces for DMX control.

### DIFF
--- a/PyDMXControl/controllers/__init__.py
+++ b/PyDMXControl/controllers/__init__.py
@@ -21,3 +21,4 @@ from ._Controller import Controller
 from ._printController import printController
 from ._transmittingController import transmittingController
 from ._uDMXController import uDMXController
+from ._serialController import SerialController

--- a/PyDMXControl/controllers/_serialController.py
+++ b/PyDMXControl/controllers/_serialController.py
@@ -31,7 +31,6 @@ class SerialController(transmittingController):
         super().close()
 
     def _send_data(self):
-
         data = [0] + self.get_frame()
         self._port.send_break(100e-6)
         time.sleep(10e-6)

--- a/PyDMXControl/controllers/_serialController.py
+++ b/PyDMXControl/controllers/_serialController.py
@@ -1,0 +1,37 @@
+"""
+ *  PyDMXControl: A Python 3 module to control DMX using uDMX.
+ *                Featuring fixture profiles, built-in effects and a web control panel.
+ *  <https://github.com/MattIPv4/PyDMXControl/>
+ *  Copyright (C) 2018 Matt Cowley (MattIPv4) (me@mattcowley.co.uk)
+"""
+
+import serial as sr
+import time as tm
+
+from ._transmittingController import transmittingController
+
+
+class SerialController(transmittingController):
+
+    def __init__(self, port, *args, **kwargs):
+        """
+        Serial port interface requires port string to establish connection, e.g. 'COM1' for
+        windows operating systems.
+
+        Parameters
+        ----------
+        port: Serial port string.
+        """
+        self._port = sr.Serial(port=port, baudrate=250000, bytesize=8, stopbits=2)
+        super().__init__(*args, **kwargs)
+
+    def close(self):
+        # Close serial port
+        self._port.close()
+        super().close()
+
+    def _send_data(self):
+
+        data = [0] + self.get_frame()
+        self._port.write(bytearray(data))
+        self._port.send_break(0.1)

--- a/PyDMXControl/controllers/_serialController.py
+++ b/PyDMXControl/controllers/_serialController.py
@@ -5,8 +5,8 @@
  *  Copyright (C) 2018 Matt Cowley (MattIPv4) (me@mattcowley.co.uk)
 """
 
-import serial as sr
-import time as tm
+from serial import Serial
+import time
 
 from ._transmittingController import transmittingController
 
@@ -22,7 +22,7 @@ class SerialController(transmittingController):
         ----------
         port: Serial port string.
         """
-        self._port = sr.Serial(port=port, baudrate=250000, bytesize=8, stopbits=2)
+        self._port = Serial(port=port, baudrate=250000, bytesize=8, stopbits=2)
         super().__init__(*args, **kwargs)
 
     def close(self):
@@ -33,5 +33,6 @@ class SerialController(transmittingController):
     def _send_data(self):
 
         data = [0] + self.get_frame()
+        self._port.send_break(100e-6)
+        time.sleep(10e-6)
         self._port.write(bytearray(data))
-        self._port.send_break(0.1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyusb
 udmx-pyusb
 flask
+pyserial


### PR DESCRIPTION
The DMX standard is a version of the RS485 serial interface. With the class provided in this pull request, you can use RS485 adapters in place of uDMX to control you DMX devices. The class requires the identifier string of the serial port as an input. 